### PR TITLE
Support append list operator and escaped double quote in string literal

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,14 @@
 
 ## Unreleased changes
 
-- Feat: keep rule args that not be overwrite by Hazell [#1](https://github.com/matsubara0507/hazell/pull/1)
+- Feat: keep `stack_snapshot` rule args that not be overwrite by Hazell [#1](https://github.com/matsubara0507/hazell/pull/1)
 - Feat: add recursive option to fetch all cabal files (for setup_deps rule arg) [#1](https://github.com/matsubara0507/hazell/pull/1)
 - Refactor: update LTS to 18.2 [#1](https://github.com/matsubara0507/hazell/pull/1)
 - Refactor: use rio package [#1](https://github.com/matsubara0507/hazell/pull/1)
+- Feat: support append list operator (`+`) [#2](https://github.com/matsubara0507/hazell/pull/2)
+- Feat: support escaped double quote in string literal [#2](https://github.com/matsubara0507/hazell/pull/2)
+- Feat: keep `haskell_library` rule args that not be overwrite by Hazell [#2](https://github.com/matsubara0507/hazell/pull/2)
+- Feat: keep key order of rule args [#2](https://github.com/matsubara0507/hazell/pull/2)
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Hazell is a Bazel build file generator for Bazel projects from hpack config file.
 
+## Usage
+
+```
+$ hazell --help
+hazell [OPTIONS] [BAZEL_PROJECT_ROOT_PATH (default ./)]
+
+Available options:
+  -V  --version              show version
+  -h  --help                 show usage
+      --package-yaml[=PATH]  PATH for package.yaml (default is ./package.yaml)
+      --stack-yaml[=PATH]    PATH for stack.yaml (default is ./stack.yaml)
+      --build[=PATH]         PATH for BUILD.bazel from bazel project root (default is BUILD.bazel)
+  -r  --recursive            Read all dependent cabal files to build files for bazel (e.g. for setup_deps)
+```
+
 ## Example
 
 ```sh

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -29,5 +29,5 @@ haskell_library(
         "@stackage//:prettyprinter",
         "@stackage//:rio",
     ],
-    compiler_flags = GHC_FLAGS,
+    compiler_flags = ["-DHOGE=1"] + GHC_FLAGS,
 )

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -19,7 +19,6 @@ haskell_library(
         "@stackage//:Cabal",
         "@stackage//:aeson",
         "@stackage//:base",
-        "@stackage//:containers",
         "@stackage//:deriving-aeson",
         "@stackage//:hpack",
         "@stackage//:http-client",

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -29,5 +29,5 @@ haskell_library(
         "@stackage//:prettyprinter",
         "@stackage//:rio",
     ],
-    compiler_flags = ["-DHOGE=1"] + GHC_FLAGS,
+    compiler_flags = ["-DDATA_FILE=\"hoge.txt\""] + GHC_FLAGS,
 )

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -42,7 +42,6 @@ stack_snapshot(
         "aeson",
         "base",
         "Cabal",
-        "containers",
         "deriving-aeson",
         "here",
         "hpack",

--- a/hazell.cabal
+++ b/hazell.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2574a2dd6c63dcf9ae235ddfe04215479559da88af75e986915b8d821750738d
+-- hash: 20ced1f10d2d8edfb5c602cf681815077dea45fd3f2946ee06e39cf752d7b1bc
 
 name:           hazell
 version:        0.1.0
@@ -44,7 +44,6 @@ library
       Cabal
     , aeson
     , base >=4.7 && <5
-    , containers
     , deriving-aeson
     , hpack
     , http-client
@@ -67,7 +66,6 @@ executable hazell
       Cabal
     , aeson
     , base >=4.7 && <5
-    , containers
     , deriving-aeson
     , hazell
     , hpack
@@ -96,7 +94,6 @@ test-suite hazell-test
       Cabal
     , aeson
     , base >=4.7 && <5
-    , containers
     , deriving-aeson
     , hazell
     , here

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,6 @@ dependencies:
 - base >= 4.7 && < 5
 - Cabal
 - deriving-aeson
-- containers
 - hpack
 - http-client
 - http-client-tls

--- a/src/Bazel/Haskell.hs
+++ b/src/Bazel/Haskell.hs
@@ -78,7 +78,6 @@ ghcPkgs =
   ,  "utf8-string"
   ]
 
--- ToDo: GHC_FLAGS
 buildHaskellLibraryRule :: Hpack.Package -> Rule
 buildHaskellLibraryRule package = Rule { .. }
   where
@@ -91,7 +90,7 @@ buildHaskellLibraryRule package = Rule { .. }
       , (Just "src_strip_prefix", RuleArgString $ toSrcDir lib)
       , (Just "srcs", RuleArgGlob $ toSrcDir lib <> "/**/*.hs")
       , (Just "deps", RuleArgArray $ map RuleArgString (dependencies lib))
-      , (Just "compiler_flags", RuleArgConst "GHC_FLAGS")
+      -- , (Just "compiler_flags", RuleArgConst "GHC_FLAGS")
       ]
     dependencies lib =
       map ("@stackage//:" <>)$ Map.keys (Hpack.unDependencies $ Hpack.sectionDependencies lib)

--- a/src/Bazel/Parser.hs
+++ b/src/Bazel/Parser.hs
@@ -131,11 +131,13 @@ comma = do
   space
 
 stringLitParser :: Parser String
-stringLitParser = do
-  char '"'
-  str <- takeWhile1P Nothing (/= '"') -- ToDo: escape "
-  char '"'
-  pure $ Text.unpack str
+stringLitParser = char '"' >> stringLitParser' ""
+  where
+    stringLitParser' :: String -> Parser String
+    stringLitParser' acc = do
+      str <- Text.unpack <$> takeWhileP Nothing (\c -> c /= '"' && c /= '\\')
+      let acc' = acc ++ str
+      (char '"' >> pure acc') <|> (char '\\' >> char '"' >> stringLitParser' (acc' ++ "\""))
 
 -- allow tail-sep
 sepAndEndBy :: MonadPlus m => m a -> (m sep, m end) -> m [a]

--- a/src/Bazel/Parser.hs
+++ b/src/Bazel/Parser.hs
@@ -66,7 +66,7 @@ buildRuleArgWithoutNameParser = (Nothing,) <$> buildRuleArgParser
 buildRuleArgParser :: Parser RuleArg
 buildRuleArgParser = do
   -- ToDo: no use sepBy for more exp
-  args <- buildRuleArgParser' `sepBy1` (space >> char '+' >> space)
+  args <- buildRuleArgParser' `sepBy1` try (space >> char '+' >> space)
   case args of
     [arg]         -> pure arg
     (arg : args') -> pure $ foldl' RuleArgAppend arg args'

--- a/src/Bazel/Parser.hs
+++ b/src/Bazel/Parser.hs
@@ -64,13 +64,21 @@ buildRuleArgWithoutNameParser :: Parser (Maybe String, RuleArg)
 buildRuleArgWithoutNameParser = (Nothing,) <$> buildRuleArgParser
 
 buildRuleArgParser :: Parser RuleArg
-buildRuleArgParser
-    = buildRuleArgArrayParser
-  <|> buildRuleArgDictParser
-  <|> buildRuleArgBoolParser
-  <|> buildRuleArgStringParser
-  <|> buildRuleArgGlobParser
-  <|> buildRuleArgConstParser
+buildRuleArgParser = do
+  -- ToDo: no use sepBy for more exp
+  args <- buildRuleArgParser' `sepBy1` (space >> char '+' >> space)
+  case args of
+    [arg]         -> pure arg
+    (arg : args') -> pure $ foldl' RuleArgAppend arg args'
+    []            -> fail "Impossible pattern"
+  where
+    buildRuleArgParser'
+        = buildRuleArgArrayParser
+      <|> buildRuleArgDictParser
+      <|> buildRuleArgBoolParser
+      <|> buildRuleArgStringParser
+      <|> buildRuleArgGlobParser
+      <|> buildRuleArgConstParser
 
 buildRuleArgStringParser :: Parser RuleArg
 buildRuleArgStringParser = RuleArgString <$> stringLitParser

--- a/src/Bazel/Rule.hs
+++ b/src/Bazel/Rule.hs
@@ -34,6 +34,7 @@ data RuleArg
   | RuleArgDict (Map String RuleArg)
   | RuleArgConst String
   | RuleArgGlob String
+  | RuleArgAppend RuleArg RuleArg
   deriving (Show, Eq)
 
 instance Pretty Rule where
@@ -43,24 +44,25 @@ instance Pretty Rule where
       callRule = prettyMethodCall name (map prettyMethodArg args)
 
 instance Pretty RuleArg where
-  pretty (RuleArgString str)  = fromString (show str)
-  pretty (RuleArgBool True)   = "True"
-  pretty (RuleArgBool False)  = "False"
-  pretty (RuleArgArray [])    = "[]"
-  pretty (RuleArgArray [arg]) = "[" <> pretty arg <> "]"
-  pretty (RuleArgArray args)  = vsep [nest 4 $ vsep ("[" : map ((<> ",") . pretty) args), "]"]
-  pretty (RuleArgDict dict)   = pretteyDict dict
-  pretty (RuleArgConst name)  = fromString name
-  pretty (RuleArgGlob path)   = "glob([" <> fromString (show path) <> "])"
+  pretty (RuleArgString str)   = fromString (show str)
+  pretty (RuleArgBool True)    = "True"
+  pretty (RuleArgBool False)   = "False"
+  pretty (RuleArgArray [])     = "[]"
+  pretty (RuleArgArray [arg])  = "[" <> pretty arg <> "]"
+  pretty (RuleArgArray args)   = vsep [nest 4 $ vsep ("[" : map ((<> ",") . pretty) args), "]"]
+  pretty (RuleArgDict dict)    = prettyDict dict
+  pretty (RuleArgConst name)   = fromString name
+  pretty (RuleArgGlob path)    = "glob([" <> fromString (show path) <> "])"
+  pretty (RuleArgAppend a1 a2) = pretty a1 <> " + " <> pretty  a2
 
-pretteyDict :: Map String RuleArg -> Doc ann
-pretteyDict dict =
+prettyDict :: Map String RuleArg -> Doc ann
+prettyDict dict =
   if Map.null dict then
     "{}"
   else
-    vsep [nest 4 $ vsep ("{" : pretteyDict' dict), "}"]
+    vsep [nest 4 $ vsep ("{" : prettyDict' dict), "}"]
   where
-    pretteyDict' = map (\(k, v) -> fromString (show k) <> ": " <> pretty v <> ",") . Map.toList
+    prettyDict' = map (\(k, v) -> fromString (show k) <> ": " <> pretty v <> ",") . Map.toList
 
 prettyMethodCall :: String -> [Doc ann] -> Doc ann
 prettyMethodCall name []    = fromString name <> "()"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-18.2
+resolver: lts-18.5
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 585392
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/2.yaml
-    sha256: 7abb45c0cc5eb349448b66d8753655542d45d387ad26970419282eab3d860724
-  original: lts-18.2
+    size: 585817
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/5.yaml
+    sha256: 22d24d0dacad9c1450b9a174c28d203f9bb482a2a8da9710a2f2a9f4afee2887
+  original: lts-18.5

--- a/test/Spec/Bazel/Build.hs
+++ b/test/Spec/Bazel/Build.hs
@@ -54,6 +54,22 @@ tests = testGroup "Bazel.Build"
         "# hoge" `assertPrettyEqual` BuildComment " hoge"
         "" `assertPrettyEqual` BuildNewline
     ]
+  , testGroup "mergeRuleArgs" $
+    let
+      newRuleArgs = [(Just "key1", RuleArgBool True), (Just "key2", RuleArgBool True)]
+    in
+      [ testCase "context is not rule" $ do
+          (BuildNewline `mergeRuleArgs` Rule "" "" newRuleArgs) @?= BuildNewline
+          (BuildComment "" `mergeRuleArgs` Rule "" "" newRuleArgs) @?= BuildComment ""
+      , testCase "context rule args is empty" $
+          (BuildRule "abc" [] `mergeRuleArgs` Rule "" "" newRuleArgs) @?= BuildRule "abc" newRuleArgs
+      , testCase "new rule args is empty" $
+          (BuildRule "abc" [(Just "key1", RuleArgBool False)] `mergeRuleArgs` Rule "" "" []) @?= BuildRule "abc" [(Just "key1", RuleArgBool False)]
+      , testCase "duplicated key1 arg" $
+          (BuildRule "abc" [(Just "key1", RuleArgBool False)] `mergeRuleArgs` Rule "" "" newRuleArgs) @?= BuildRule "abc" newRuleArgs
+      , testCase "different keys order" $
+          (BuildRule "abc" [(Just "key2", RuleArgBool False), (Just "key1", RuleArgBool False)] `mergeRuleArgs` Rule "" "" newRuleArgs) @?= BuildRule "abc" [(Just "key2", RuleArgBool True), (Just "key1", RuleArgBool True)]
+      ]
   ]
 
 


### PR DESCRIPTION
- Support append list operator (`+`)
- Support escaped double quote in string literal
- Keep `haskell_library` rule args that not be overwrite by Hazell
- Keep key order of rule args 